### PR TITLE
アイテム小画面表示を追加

### DIFF
--- a/data/scenario/Conversation/epilogue/episode_normal_ep.ks
+++ b/data/scenario/Conversation/epilogue/episode_normal_ep.ks
@@ -29,9 +29,12 @@
 #深雪
 えっ、これは...[p]
 
-;[autostop]
-;[skipstop]
-;[ItemDisp storage="../image/episode1/cable.png"]
+[iscript]
+    f.charaPosition[0] = 'miyuki'
+    f.charaPosition[1] = 'left'
+[endscript]
+[ChangeCharaPosition]
+;[ItemDisp storage=""]
 [ChangeCharaFace name="miyuki" face="trouble"]
 #深雪
 「おめでとう！[rhr]
@@ -43,9 +46,12 @@ _　脱出成功だよ！！」[p]
 #深雪
 「追伸：もっと勇気を出すといいことあるかも！」...？[p]
 
-;[autostop]
-;[skipstop]
 ;[FreeItemDisp]
+[iscript]
+    f.charaPosition[0] = 'miyuki'
+    f.charaPosition[1] = 'center'
+[endscript]
+[ChangeCharaPosition]
 [DispTrouble_Center x="1040"]
 #深雪
 何なのこれは？[p]

--- a/data/scenario/Conversation/episode1/episode1_04.ks
+++ b/data/scenario/Conversation/episode1/episode1_04.ks
@@ -28,26 +28,20 @@
     数字の手がかりになりそうなものを探してみましょう。[p]
 ; 箱開封時
 [elsif exp="f.leftNum == 4 && f.centerNum == 5 && f.rightNum == 6"]
-    [ShowMiyuki_Center]
+    [ItemDisp storage="../image/episode1/cable.png"]
+    [ShowMiyuki_Left]
     #深雪
     箱が空いたようね。[r]
     中身は...ケーブルかしら。[p]
 
-    [iscript]
-        f.charaPosition[0] = 'miyuki'
-        f.charaPosition[1] = 'left'
-    [endscript]
-    [ChangeCharaPosition]
     [DispSparkle_Right]
     [ShowSakura_Right face="smile"]
-    ;[autostop]
-    ;[skipstop]
-    ;[ItemDisp storage="../image/episode1/cable.png"]
     #桜良
     深雪ちゃん、すごい！[r]
     ステージの装飾がヒントだったなんて、[r]
     私全然気づかなかった！[p]
 
+    [FreeItemDisp]
     [FreeDispSparkle]
     [ChangeCharaFace name="miyuki" face="close_eye"]
     #深雪

--- a/data/scenario/Conversation/episode1/episode1_op.ks
+++ b/data/scenario/Conversation/episode1/episode1_op.ks
@@ -117,8 +117,6 @@ _　きゅんきゅんしちゃうじゃない！）[p]
 #深雪
 見せて。[p]
 
-;[autostop]
-;[skipstop]
 ;[ItemDisp storage=""]
 #深雪
 『仲良く謎解きしないと出られない部屋』？[p]
@@ -144,8 +142,6 @@ _　しっかりしてるなあ。[p]
 あっ！[p]
 
 [FreeDispSurprised]
-;[autostop]
-;[skipstop]
 ;[FreeItemDisp]
 ; 桜良漫符：びっくり
 [DispSurprised_Right]

--- a/data/scenario/Conversation/episode2/episode2_05.ks
+++ b/data/scenario/Conversation/episode2/episode2_05.ks
@@ -16,9 +16,7 @@
 [ChangeCharaPosition]
 [DispSurprised_Left]
 [ShowMiyuki_Left face="surprise"]
-;[autostop]
-;[skipstop]
-;[ItemDisp storage="../image/episode2/dreass.png"]
+[ItemDisp storage="../image/episode2/dress.png" x="760" width="350" height="350"]
 #深雪
 よくある安物のコスプレ衣装でもないみたいね。[r]
 私たちが実際に使っていた本物だわ。[p]
@@ -35,6 +33,7 @@ _　やっぱりこれは撮影？）[p]
 （でも、部屋を探しても隠しカメラがあるようには見えなかった。[r]
 _　私が見逃しているだけなのか、それとも...）[p]
 
+[FreeItemDisp]
 [ChangeCharaFace name="sakura" face="normal"]
 #桜良
 ここに衣装があるってことは、[r]

--- a/data/scenario/Macro/direction.ks
+++ b/data/scenario/Macro/direction.ks
@@ -75,9 +75,11 @@
 
 ; アイテム小画面表示
 [macro name="ItemDisp"]
+    [autostop]
+    [skipstop]
     [layer2True]
     [DarkenBackground]
-    [image storage="%storage" layer="2" x="780" y="350" width="250" height="250" name="itemDisp" time="10" wait="true"]
+    [image storage="%storage" layer="2" x="%x|780" y="%y|350" width="%width|250" height="%height|250" name="itemDisp" time="10" wait="true"]
 [endmacro]
 
 ; アイテム小画面表示を解除


### PR DESCRIPTION
以下のタスクを対応

- [共通]会話中にキーとなるアイテムを中央に表示する #184